### PR TITLE
refactor: convert capabilities and jobs pages to list view with table…

### DIFF
--- a/src/routes/_public/capabilities/$slug/index.tsx
+++ b/src/routes/_public/capabilities/$slug/index.tsx
@@ -1,9 +1,9 @@
 import { Link, createFileRoute, notFound } from '@tanstack/react-router'
 
 import { getCapabilityBySlugFn } from '@/actions/capabilities'
+import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
 import { Progress } from '@/components/ui/progress'
 
 export const Route = createFileRoute('/_public/capabilities/$slug/')({
@@ -36,11 +36,6 @@ function CapabilityPage() {
       subtypes.length,
   )
 
-  // Determine overall status
-  let overallStatus: 'solved' | 'partial' | 'unsolved' = 'unsolved'
-  if (overallProgress >= 80) overallStatus = 'solved'
-  else if (overallProgress >= 30) overallStatus = 'partial'
-
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'solved':
@@ -72,9 +67,6 @@ function CapabilityPage() {
         return ''
     }
   }
-
-  const statusTitle =
-    overallStatus.charAt(0).toUpperCase() + overallStatus.slice(1)
 
   return (
     <>
@@ -115,12 +107,6 @@ function CapabilityPage() {
                   <span className="font-semibold">{overallProgress}%</span>
                 </div>
                 <Progress value={overallProgress} className="w-32 h-2" />
-                <Badge
-                  variant="outline"
-                  className={getStatusColor(overallStatus)}
-                >
-                  {getStatusIcon(overallStatus)} {statusTitle}
-                </Badge>
                 <span className="text-sm text-muted-foreground">
                   {subtypes.length} domains tracked
                 </span>
@@ -140,98 +126,68 @@ function CapabilityPage() {
             Progress varies dramatically across different fields:
           </p>
 
-          <div className="grid grid-cols-1 gap-6 mb-8">
-            {subtypes.map((subtype: any) => {
-              const subtypeStatus =
-                subtype.status.charAt(0).toUpperCase() + subtype.status.slice(1)
-              return (
-                <Card key={subtype.id} className="overflow-hidden">
-                  <CardContent className="p-6">
-                    <div className="flex items-start justify-between gap-6">
-                      <div className="flex-1">
-                        <div className="flex items-center gap-3 mb-3">
-                          <h3 className="text-xl font-semibold">
-                            {subtype.name}
-                          </h3>
-                          <Badge
-                            variant="outline"
-                            className={getStatusColor(subtype.status)}
-                          >
-                            {getStatusIcon(subtype.status)} {subtypeStatus}
-                          </Badge>
-                          <span className="text-sm text-muted-foreground">
-                            • {subtype.domain}
-                          </span>
-                        </div>
+          <div className="border border-border/40 rounded-md overflow-hidden mb-8">
+            {/* Header */}
+            <div className="bg-muted/50 flex items-center">
+              <div className="flex-1 px-4 py-3">
+                <p className="text-sm font-medium">Name</p>
+              </div>
+              <div className="flex items-center gap-4 px-4 py-3">
+                <p className="text-sm font-medium whitespace-nowrap">Progress</p>
+                <p className="text-sm font-medium whitespace-nowrap">Status</p>
+              </div>
+            </div>
 
-                        <div className="flex items-center gap-3 mb-4">
-                          <span className="text-sm text-muted-foreground">
-                            Progress:
-                          </span>
-                          <span className="font-semibold">
+            {/* Rows */}
+            <div>
+              {subtypes.map((subtype: any, index) => {
+                const subtypeStatus =
+                  subtype.status.charAt(0).toUpperCase() + subtype.status.slice(1)
+                return (
+                  <Link
+                    key={subtype.id}
+                    to="/capabilities/$slug/$subslug"
+                    params={{
+                      slug: capability.slug,
+                      subslug: subtype.slug,
+                    }}
+                    className="group block"
+                  >
+                    <div className={cn(
+                      'flex items-center border-t border-border/40 hover:bg-muted/30 transition-colors',
+                      index === subtypes.length - 1 ? '' : 'border-b'
+                    )}>
+                      <div className="flex-1 px-4 py-3 min-w-0">
+                        <h3 className="font-semibold group-hover:text-primary transition-colors truncate">
+                          {subtype.name}
+                        </h3>
+                        <p className="text-xs text-muted-foreground truncate">
+                          {subtype.domain}
+                        </p>
+                      </div>
+
+                      <div className="flex items-center gap-4 px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs text-muted-foreground whitespace-nowrap">
                             {subtype.progressPercentage}%
                           </span>
                           <Progress
                             value={subtype.progressPercentage}
-                            className="w-24 h-2"
+                            className="h-1.5 w-16 sm:w-32 md:w-40 lg:w-60"
                           />
                         </div>
-
-                        {subtype.whatWorks && subtype.whatWorks.length > 0 && (
-                          <div className="mb-4">
-                            <p className="text-sm font-medium mb-2">
-                              ✅ What works:
-                            </p>
-                            <ul className="text-sm text-muted-foreground space-y-1 ml-4">
-                              {subtype.whatWorks
-                                .slice(0, 3)
-                                .map((item: string, i: number) => (
-                                  <li key={i}>{item}</li>
-                                ))}
-                              {subtype.whatWorks.length > 3 && (
-                                <li className="text-xs">
-                                  +{subtype.whatWorks.length - 3} more
-                                </li>
-                              )}
-                            </ul>
-                          </div>
-                        )}
-
-                        {subtype.whatStruggles.length > 0 && (
-                          <div className="mb-4">
-                            <p className="text-sm font-medium mb-2">
-                              ⚠️ What struggles:
-                            </p>
-                            <ul className="text-sm text-muted-foreground space-y-1 ml-4">
-                              {subtype.whatStruggles
-                                .slice(0, 3)
-                                .map((item: string, i: number) => (
-                                  <li key={i}>{item}</li>
-                                ))}
-                              {subtype.whatStruggles.length > 3 && (
-                                <li className="text-xs">
-                                  +{subtype.whatStruggles.length - 3} more
-                                </li>
-                              )}
-                            </ul>
-                          </div>
-                        )}
+                        <Badge
+                          variant="outline"
+                          className={`${getStatusColor(subtype.status)} min-w-[100px] justify-center`}
+                        >
+                          {getStatusIcon(subtype.status)} {subtypeStatus}
+                        </Badge>
                       </div>
-
-                      <Link
-                        to="/capabilities/$slug/$subslug"
-                        params={{
-                          slug: capability.slug,
-                          subslug: subtype.slug,
-                        }}
-                      >
-                        <Button variant="outline">View full details →</Button>
-                      </Link>
                     </div>
-                  </CardContent>
-                </Card>
-              )
-            })}
+                  </Link>
+                )
+              })}
+            </div>
           </div>
 
           {subtypes.length === 0 && (
@@ -241,50 +197,6 @@ function CapabilityPage() {
               </p>
             </div>
           )}
-        </section>
-
-        {/* Progress Comparison */}
-        <section className="bg-muted/30 py-12">
-          <div className="container mx-auto px-6">
-            <h2 className="text-2xl font-semibold mb-4">
-              📈 Progress Comparison
-            </h2>
-            <p className="text-muted-foreground mb-8">
-              How {capability.name.toLowerCase()} capabilities compare across
-              domains:
-            </p>
-
-            <Card>
-              <CardContent className="p-6">
-                <div className="space-y-4">
-                  {subtypes.map((subtype: any) => (
-                    <div key={subtype.id}>
-                      <div className="flex items-center justify-between mb-2">
-                        <span className="text-sm font-medium">
-                          {subtype.name}
-                        </span>
-                        <span className="text-sm text-muted-foreground">
-                          {subtype.progressPercentage}%
-                        </span>
-                      </div>
-                      <Progress
-                        value={subtype.progressPercentage}
-                        className="h-2"
-                      />
-                    </div>
-                  ))}
-                </div>
-
-                {subtypes.length > 0 && (
-                  <div className="mt-6 pt-6 border-t border-border/40">
-                    <p className="text-sm text-muted-foreground">
-                      Average progress: {overallProgress}%
-                    </p>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </div>
         </section>
 
         {/* CTA */}

--- a/src/routes/_public/capabilities/$slug/index.tsx
+++ b/src/routes/_public/capabilities/$slug/index.tsx
@@ -31,21 +31,22 @@ function CapabilityPage() {
   const { subtypes, ...capability } = result.data
 
   // Calculate overall progress from subtypes
-  const overallProgress = Math.round(
-    subtypes.reduce((sum: number, s: any) => sum + s.progressPercentage, 0) /
-      subtypes.length,
-  )
+  const overallProgress =
+    subtypes.length === 0
+      ? 0
+      : Math.round(
+          subtypes.reduce((sum: number, s: any) => sum + s.progressPercentage, 0) /
+            subtypes.length,
+        )
 
   const getStatusColor = (status: string) => {
-    switch (status) {
+    const normalizedStatus = status.toLowerCase()
+    switch (normalizedStatus) {
       case 'solved':
-      case 'Solved':
         return 'bg-green-500/10 text-green-500 dark:text-green-400 border-green-500/20'
       case 'partial':
-      case 'Partial':
         return 'bg-yellow-500/10 text-yellow-500 dark:text-yellow-400 border-yellow-500/20'
       case 'unsolved':
-      case 'Unsolved':
         return 'bg-red-500/10 text-red-500 dark:text-red-400 border-red-500/20'
       default:
         return ''
@@ -53,15 +54,13 @@ function CapabilityPage() {
   }
 
   const getStatusIcon = (status: string) => {
-    switch (status) {
+    const normalizedStatus = status.toLowerCase()
+    switch (normalizedStatus) {
       case 'solved':
-      case 'Solved':
         return '✅'
       case 'partial':
-      case 'Partial':
         return '⚠️'
       case 'unsolved':
-      case 'Unsolved':
         return '❌'
       default:
         return ''
@@ -154,8 +153,8 @@ function CapabilityPage() {
                     className="group block"
                   >
                     <div className={cn(
-                      'flex items-center border-t border-border/40 hover:bg-muted/30 transition-colors',
-                      index === subtypes.length - 1 ? '' : 'border-b'
+                      'flex items-center hover:bg-muted/30 transition-colors',
+                      index === subtypes.length - 1 ? '' : 'border-b border-border/40'
                     )}>
                       <div className="flex-1 px-4 py-3 min-w-0">
                         <h3 className="font-semibold group-hover:text-primary transition-colors truncate">
@@ -178,7 +177,10 @@ function CapabilityPage() {
                         </div>
                         <Badge
                           variant="outline"
-                          className={`${getStatusColor(subtype.status)} min-w-[100px] justify-center`}
+                          className={cn(
+                            getStatusColor(subtype.status),
+                            'min-w-[100px] justify-center'
+                          )}
                         >
                           {getStatusIcon(subtype.status)} {subtypeStatus}
                         </Badge>

--- a/src/routes/_public/capabilities/index.tsx
+++ b/src/routes/_public/capabilities/index.tsx
@@ -1,25 +1,17 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
 
-import {
-  getAllCapabilitiesFn,
-  getOverallProgressFn,
-} from '@/actions/capabilities'
-import { Badge } from '@/components/ui/badge'
+import { getAllCapabilitiesFn } from '@/actions/capabilities'
+import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
 import { Progress } from '@/components/ui/progress'
 
 export const Route = createFileRoute('/_public/capabilities/')({
   component: CapabilitiesPage,
   loader: async () => {
-    const [capabilities, overallProgress] = await Promise.all([
-      getAllCapabilitiesFn(),
-      getOverallProgressFn(),
-    ])
+    const capabilities = await getAllCapabilitiesFn()
 
     return {
       capabilities,
-      overallProgress,
     }
   },
   pendingComponent: () => (
@@ -33,39 +25,13 @@ export const Route = createFileRoute('/_public/capabilities/')({
 })
 
 function CapabilitiesPage() {
-  const { capabilities, overallProgress } = Route.useLoaderData()
+  const { capabilities } = Route.useLoaderData()
 
   // Transform data for display
   const capabilitiesList = capabilities.map((cap) => ({
     ...cap,
     status: cap.status.charAt(0).toUpperCase() + cap.status.slice(1),
   }))
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'Solved':
-        return 'bg-green-500/10 text-green-500 dark:text-green-400 border-green-500/20'
-      case 'Partial':
-        return 'bg-yellow-500/10 text-yellow-500 dark:text-yellow-400 border-yellow-500/20'
-      case 'Unsolved':
-        return 'bg-red-500/10 text-red-500 dark:text-red-400 border-red-500/20'
-      default:
-        return ''
-    }
-  }
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'Solved':
-        return '✅'
-      case 'Partial':
-        return '⚠️'
-      case 'Unsolved':
-        return '❌'
-      default:
-        return ''
-    }
-  }
 
   return (
     <>
@@ -87,98 +53,58 @@ function CapabilitiesPage() {
 
       {/* Capabilities List */}
       <section className="container mx-auto px-6 py-12">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {capabilitiesList.map((capability) => (
-            <Link
-              key={capability.slug}
-              to="/capabilities/$slug"
-              params={{ slug: capability.slug }}
-              className="group"
-            >
-              <Card className="h-full transition-all hover:shadow-lg hover:border-primary/50">
-                <CardContent className="p-6">
-                  <div className="flex items-start justify-between mb-4">
-                    <div>
-                      <h3 className="font-semibold group-hover:text-primary transition-colors">
-                        {capability.name}
-                      </h3>
-                    </div>
-                    <Badge
-                      variant="outline"
-                      className={getStatusColor(capability.status)}
-                    >
-                      {getStatusIcon(capability.status)} {capability.status}
-                    </Badge>
+        <div className="border border-border/40 rounded-md overflow-hidden">
+          {/* Header */}
+          <div className="bg-muted/50 flex items-center">
+            <div className="flex-1 px-4 py-3">
+              <p className="text-sm font-medium">Name</p>
+            </div>
+            <div className="flex items-center gap-4 px-4 py-3">
+              <p className="text-sm font-medium whitespace-nowrap">Progress</p>
+              <p className="text-sm font-medium whitespace-nowrap">Subtypes</p>
+              <p className="text-sm font-medium whitespace-nowrap w-8"></p>
+            </div>
+          </div>
+
+          {/* Rows */}
+          <div>
+            {capabilitiesList.map((capability, index) => (
+              <Link
+                key={capability.slug}
+                to="/capabilities/$slug"
+                params={{ slug: capability.slug }}
+                className="group block"
+              >
+                <div className={cn(
+                  'flex items-center border-t border-border/40 hover:bg-muted/30 transition-colors',
+                  index === capabilitiesList.length - 1 ? '' : 'border-b'
+                )}>
+                  <div className="flex-1 px-4 py-3 min-w-0">
+                    <h3 className="font-semibold group-hover:text-primary transition-colors truncate">
+                      {capability.name}
+                    </h3>
                   </div>
 
-                  <p className="text-sm text-muted-foreground mb-4">
-                    {capability.description}
-                  </p>
-
-                  <div className="space-y-3">
-                    <div>
-                      <div className="flex items-center justify-between mb-1">
-                        <span className="text-xs text-muted-foreground">
-                          Overall Progress
-                        </span>
-                        <span className="text-xs font-medium">
-                          {capability.progress}%
-                        </span>
-                      </div>
-                      <Progress value={capability.progress} className="h-2" />
+                  <div className="flex items-center gap-4 px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-muted-foreground whitespace-nowrap">
+                        {capability.progress}%
+                      </span>
+                      <Progress
+                        value={capability.progress}
+                        className="h-1.5 w-16 sm:w-32 md:w-60 lg:w-80"
+                      />
                     </div>
-
-                    <div className="flex items-center justify-between text-xs text-muted-foreground pt-2 border-t border-border/40">
-                      <span>{capability.subtypesCount} subtypes</span>
-                      <span>View details →</span>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
-          ))}
-        </div>
-      </section>
-
-      {/* Overall Progress */}
-      <section className="bg-muted/30 py-12">
-        <div className="container mx-auto px-6">
-          <div className="max-w-3xl mx-auto">
-            <h2 className="text-2xl font-semibold mb-4">
-              Overall AGI Progress
-            </h2>
-            <p className="text-muted-foreground mb-8">
-              Average progress across all capability domains
-            </p>
-
-            <Card>
-              <CardContent className="p-6">
-                <div className="space-y-4">
-                  {capabilitiesList.map((cap) => (
-                    <div key={cap.slug}>
-                      <div className="flex items-center justify-between mb-2">
-                        <span className="text-sm font-medium">{cap.name}</span>
-                        <span className="text-sm text-muted-foreground">
-                          {cap.progress}%
-                        </span>
-                      </div>
-                      <Progress value={cap.progress} className="h-2" />
-                    </div>
-                  ))}
-                </div>
-
-                <div className="mt-6 pt-6 border-t border-border/40 text-center">
-                  <p className="text-sm text-muted-foreground">
-                    <span className="font-semibold text-foreground">
-                      Average Progress: {overallProgress.overall}%
+                    <span className="text-xs text-muted-foreground whitespace-nowrap">
+                      {capability.subtypesCount} subtypes
                     </span>
-                    <br />
-                    AI is making steady progress, but significant gaps remain in
-                    domain-specific reasoning and real-world applications.
-                  </p>
+                    <span className="text-muted-foreground group-hover:text-primary transition-colors whitespace-nowrap w-8">
+                      →
+                    </span>
+                  </div>
                 </div>
-              </CardContent>
-            </Card>
+              </Link>
+            ))}
           </div>
         </div>
       </section>

--- a/src/routes/_public/capabilities/index.tsx
+++ b/src/routes/_public/capabilities/index.tsx
@@ -36,7 +36,6 @@ function CapabilitiesPage() {
   return (
     <>
       {/* Hero Section */}
-      {/* Hero Section */}
       <section className="border-b border-border/40 bg-muted/30">
         <div className="container mx-auto px-6 py-16">
           <div className="max-w-3xl">
@@ -76,8 +75,8 @@ function CapabilitiesPage() {
                 className="group block"
               >
                 <div className={cn(
-                  'flex items-center border-t border-border/40 hover:bg-muted/30 transition-colors',
-                  index === capabilitiesList.length - 1 ? '' : 'border-b'
+                  'flex items-center hover:bg-muted/30 transition-colors',
+                  index === capabilitiesList.length - 1 ? '' : 'border-b border-border/40'
                 )}>
                   <div className="flex-1 px-4 py-3 min-w-0">
                     <h3 className="font-semibold group-hover:text-primary transition-colors truncate">

--- a/src/routes/_public/jobs/index.tsx
+++ b/src/routes/_public/jobs/index.tsx
@@ -4,9 +4,9 @@ import { Search } from 'lucide-react'
 import { useCallback } from 'react'
 
 import { getJobsPaginatedFn } from '@/actions/jobs'
+import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Progress } from '@/components/ui/progress'
 import {
@@ -109,12 +109,6 @@ function JobsPage() {
     if (risk >= 70) return 'text-red-500'
     if (risk >= 40) return 'text-yellow-500'
     return 'text-green-500'
-  }
-
-  const getRiskLabel = (risk: number) => {
-    if (risk >= 70) return 'High Risk'
-    if (risk >= 40) return 'Medium Risk'
-    return 'Low Risk'
   }
 
   const categoryLabel = (category: string) => {
@@ -310,59 +304,67 @@ function JobsPage() {
       <section className="container mx-auto px-6 pb-12">
         {jobs.length > 0 ? (
           <>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {jobs.map((job: any) => (
-                <Link
-                  key={job.id}
-                  to="/jobs/$slug"
-                  params={{ slug: job.slug }}
-                  className="group"
-                >
-                  <Card className="h-full transition-all hover:shadow-lg hover:border-primary/50">
-                    <CardContent className="p-6">
-                      <div className="flex items-start justify-between mb-4">
-                        <div>
-                          <h3 className="font-semibold group-hover:text-primary transition-colors">
-                            {job.name}
-                          </h3>
-                          <p className="text-xs text-muted-foreground">
-                            {categoryLabel(job.category)}
-                          </p>
+            <div className="border border-border/40 rounded-md overflow-hidden">
+              {/* Header */}
+              <div className="bg-muted/50 flex items-center">
+                <div className="flex-1 px-4 py-3">
+                  <p className="text-sm font-medium">Name</p>
+                </div>
+                <div className="flex items-center gap-4 px-4 py-3">
+                  <p className="text-sm font-medium whitespace-nowrap">AI Impact Progress</p>
+                  <p className="text-sm font-medium whitespace-nowrap w-[100px] text-center">Status</p>
+                  <p className="text-sm font-medium whitespace-nowrap w-8"></p>
+                </div>
+              </div>
+
+              {/* Rows */}
+              <div>
+                {jobs.map((job: any, index: number) => (
+                  <Link
+                    key={job.id}
+                    to="/jobs/$slug"
+                    params={{ slug: job.slug }}
+                    className="group block"
+                  >
+                    <div className={cn(
+                      'flex items-center border-t border-border/40 hover:bg-muted/30 transition-colors',
+                      index === jobs.length - 1 ? '' : 'border-b'
+                    )}>
+                      <div className="flex-1 px-4 py-3 min-w-0">
+                        <h3 className="font-semibold group-hover:text-primary transition-colors truncate">
+                          {job.name}
+                        </h3>
+                        <p className="text-xs text-muted-foreground truncate">
+                          {categoryLabel(job.category)}
+                        </p>
+                      </div>
+
+                      <div className="flex items-center gap-4 px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`text-xs font-medium ${getRiskColor(job.automationRiskPercentage)}`}
+                          >
+                            {job.automationRiskPercentage}%
+                          </span>
+                          <Progress
+                            value={job.automationRiskPercentage}
+                            className="h-1.5 w-16 sm:w-32 md:w-40 lg:w-60"
+                          />
                         </div>
                         <Badge
                           variant="outline"
-                          className={getRiskColor(job.automationRiskPercentage)}
+                          className={`${getRiskColor(job.automationRiskPercentage)} min-w-[100px] justify-center`}
                         >
-                          {getRiskLabel(job.automationRiskPercentage)}
+                          {job.riskLevel}
                         </Badge>
+                        <span className="text-muted-foreground group-hover:text-primary transition-colors whitespace-nowrap w-8">
+                          →
+                        </span>
                       </div>
-
-                      <div className="space-y-3">
-                        <div>
-                          <div className="flex items-center justify-between mb-1">
-                            <span className="text-xs text-muted-foreground">
-                              Automation Risk
-                            </span>
-                            <span
-                              className={`text-xs font-medium ${getRiskColor(job.automationRiskPercentage)}`}
-                            >
-                              {job.automationRiskPercentage}%
-                            </span>
-                          </div>
-                          <Progress
-                            value={job.automationRiskPercentage}
-                            className="h-2"
-                          />
-                        </div>
-
-                        <div className="flex items-center justify-between text-xs text-muted-foreground pt-2 border-t border-border/40">
-                          <span>View analysis →</span>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </Link>
-              ))}
+                    </div>
+                  </Link>
+                ))}
+              </div>
             </div>
 
             {/* Pagination */}

--- a/src/routes/_public/jobs/index.tsx
+++ b/src/routes/_public/jobs/index.tsx
@@ -17,6 +17,20 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 
+type Job = {
+  id: string
+  slug: string
+  name: string
+  category: string
+  description: string
+  icon: string | null
+  automationRiskPercentage: number
+  riskLevel: string
+  timelineEstimate: string | null
+  confidence: string
+  createdAt: Date
+}
+
 // Search params schema for the jobs page
 const jobsSearchSchema = {
   page: 1,
@@ -319,7 +333,7 @@ function JobsPage() {
 
               {/* Rows */}
               <div>
-                {jobs.map((job: any, index: number) => (
+                {jobs.map((job: Job, index: number) => (
                   <Link
                     key={job.id}
                     to="/jobs/$slug"
@@ -327,8 +341,8 @@ function JobsPage() {
                     className="group block"
                   >
                     <div className={cn(
-                      'flex items-center border-t border-border/40 hover:bg-muted/30 transition-colors',
-                      index === jobs.length - 1 ? '' : 'border-b'
+                      'flex items-center hover:bg-muted/30 transition-colors',
+                      index === jobs.length - 1 ? '' : 'border-b border-border/40'
                     )}>
                       <div className="flex-1 px-4 py-3 min-w-0">
                         <h3 className="font-semibold group-hover:text-primary transition-colors truncate">
@@ -353,7 +367,10 @@ function JobsPage() {
                         </div>
                         <Badge
                           variant="outline"
-                          className={`${getRiskColor(job.automationRiskPercentage)} min-w-[100px] justify-center`}
+                          className={cn(
+                            getRiskColor(job.automationRiskPercentage),
+                            'min-w-[100px] justify-center'
+                          )}
                         >
                           {job.riskLevel}
                         </Badge>


### PR DESCRIPTION
…-like structure

- Convert capabilities grid cards to list view with headers (Name, Progress, Subtypes)
- Convert sub-capabilities grid cards to list view with headers (Name, Progress, Status)
- Convert jobs grid cards to list view with headers (Name, AI Impact Progress, Status)
- Add responsive progress bar widths (w-16 to w-80 based on screen size)
- Remove overall AGI Progress section from capabilities
- Remove Progress Comparison section from capability detail page
- Remove status badge from capability header overall progress
- Use cn utility for conditional classes instead of template literals
- Clean up unused imports and variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned capabilities and jobs lists from card grids to bordered, row-based table layouts with persistent header rows for Name, Progress and Status/Subtypes.
  * Made each item a clickable row showing name, progress bar and status/risk badge; simplified per-item details and removed secondary “what works/struggles” sections.
  * Removed the overall progress/status header and the Progress Comparison section; retained hero and CTA areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->